### PR TITLE
Fix namcap warning about name of non standard variables

### DIFF
--- a/PKGBUILD
+++ b/PKGBUILD
@@ -4,9 +4,9 @@ pkgbase=libnvidia-container
 pkgname=(libnvidia-container libnvidia-container-tools)
 
 pkgver=1.0.0
-rpcver=1.1.4
-elfver=0.7.1
-nvmpver=396.51
+_rpcver=1.1.4
+_elfver=0.7.1
+_nvmpver=396.51
 
 pkgrel=1
 pkgdesc='NVIDIA container runtime library'
@@ -27,8 +27,8 @@ options=(!makeflags)
 # https://github.com/NVIDIA/libnvidia-container/blob/e3a2035da5a44b8a83d9568b91a8a0b542ee15d5/mk/elftoolchain.mk
 # https://github.com/NVIDIA/libnvidia-container/blob/56704b8dd297bf4daf82a2da4b270dc7f14e0008/mk/nvidia-modprobe.mk
 source=("https://github.com/NVIDIA/${pkgname}/archive/v${pkgver}.tar.gz"
-        "https://downloads.sourceforge.net/project/libtirpc/libtirpc/${rpcver}/libtirpc-${rpcver}.tar.bz2"
-        "https://sourceforge.net/projects/elftoolchain/files/Sources/elftoolchain-${elfver}/elftoolchain-${elfver}.tar.bz2"
+        "https://downloads.sourceforge.net/project/libtirpc/libtirpc/${_rpcver}/libtirpc-${_rpcver}.tar.bz2"
+        "https://sourceforge.net/projects/elftoolchain/files/Sources/elftoolchain-${_elfver}/elftoolchain-${_elfver}.tar.bz2"
         "https://github.com/NVIDIA/nvidia-modprobe/archive/396.51.tar.gz")
 sha256sums=('5c8ca77e490fd9a0a47020fa0d6d9842af4951bfcb12d189db37ad5524b67f27'
             '2ca529f02292e10c158562295a1ffd95d2ce8af97820e3534fe1b0e3aec7561d'
@@ -43,7 +43,7 @@ prepare(){
   deps_dir="${srcdir}/${pkgname}-${pkgver}/deps/src/"
   # mimic behavior from:
   # https://github.com/NVIDIA/libnvidia-container/blob/56704b8dd297bf4daf82a2da4b270dc7f14e0008/mk/libtirpc.mk
-  for dep in "libtirpc-${rpcver}.tar.bz2" "elftoolchain-${elfver}.tar.bz2" "${nvmpver}.tar.gz"; do
+  for dep in "libtirpc-${_rpcver}.tar.bz2" "elftoolchain-${_elfver}.tar.bz2" "${_nvmpver}.tar.gz"; do
     dep_dir="${deps_dir}/${dep%.tar*}"
     mkdir -p ${dep_dir}
     # untar the download into the deps dir
@@ -53,8 +53,8 @@ prepare(){
   done
 
   # the tar isn't named correctly, so the dir needs moving
-  if [ ! -d "${deps_dir}/nvidia-modprobe-${nvmpver}" ]; then
-    mv "${deps_dir}/${nvmpver}" "${deps_dir}/nvidia-modprobe-${nvmpver}"
+  if [ ! -d "${deps_dir}/nvidia-modprobe-${_nvmpver}" ]; then
+    mv "${deps_dir}/${_nvmpver}" "${deps_dir}/nvidia-modprobe-${_nvmpver}"
   fi
 }
 


### PR DESCRIPTION
Fix [namcap](https://wiki.archlinux.org/index.php/Creating_packages#Checking_package_sanity) warning about name of non standard variables

```
PKGBUILD (libnvidia-container) W: Non standard variable 'elfver' doesn't start with an underscore
PKGBUILD (libnvidia-container) W: Non standard variable 'nvmpver' doesn't start with an underscore
PKGBUILD (libnvidia-container) W: Non standard variable 'rpcver' doesn't start with an underscore
```