### PR TITLE
Remove libtirpc from source

### DIFF
--- a/.SRCINFO
+++ b/.SRCINFO
@@ -7,17 +7,14 @@ pkgbase = libnvidia-container
 	license = custom
 	makedepends = bmake
 	makedepends = lsb-release
-	makedepends = rpcsvc-proto
 	depends = libcap
 	depends = libseccomp
 	depends = libtirpc
 	options = !makeflags
 	source = https://github.com/NVIDIA/libnvidia-container/archive/v1.0.0.tar.gz
-	source = https://downloads.sourceforge.net/project/libtirpc/libtirpc/1.1.4/libtirpc-1.1.4.tar.bz2
 	source = https://sourceforge.net/projects/elftoolchain/files/Sources/elftoolchain-0.7.1/elftoolchain-0.7.1.tar.bz2
 	source = https://github.com/NVIDIA/nvidia-modprobe/archive/396.51.tar.gz
 	sha256sums = 5c8ca77e490fd9a0a47020fa0d6d9842af4951bfcb12d189db37ad5524b67f27
-	sha256sums = 2ca529f02292e10c158562295a1ffd95d2ce8af97820e3534fe1b0e3aec7561d
 	sha256sums = 44f14591fcf21294387215dd7562f3fb4bec2f42f476cf32420a6bbabb2bd2b5
 	sha256sums = 25bc6437a384be670e9fd76ac2e5b9753517e23eb16e7fa891b18537b70c4b20
 

--- a/.SRCINFO
+++ b/.SRCINFO
@@ -21,7 +21,5 @@ pkgbase = libnvidia-container
 pkgname = libnvidia-container
 
 pkgname = libnvidia-container-tools
-	depends = libcap
-	depends = libtirpc
 	depends = libnvidia-container
 

--- a/PKGBUILD
+++ b/PKGBUILD
@@ -86,7 +86,7 @@ package_libnvidia-container() {
 }
 
 package_libnvidia-container-tools() {
-  depends=(libcap libtirpc libnvidia-container)
+  depends=(libnvidia-container)
 
   make_dist
 

--- a/PKGBUILD
+++ b/PKGBUILD
@@ -4,7 +4,6 @@ pkgbase=libnvidia-container
 pkgname=(libnvidia-container libnvidia-container-tools)
 
 pkgver=1.0.0
-_rpcver=1.1.4
 _elfver=0.7.1
 _nvmpver=396.51
 
@@ -14,7 +13,7 @@ arch=('x86_64')
 url='https://github.com/NVIDIA/libnvidia-container'
 license=('custom')
 
-makedepends=(bmake lsb-release rpcsvc-proto)
+makedepends=(bmake lsb-release)
 depends=(libcap libseccomp libtirpc)
 
 # yikes! somehow the default flags cause a linking error :(
@@ -23,15 +22,12 @@ options=(!makeflags)
 # This make process downloads files from other sources to build the libs as deps cleanly in place.
 # This pkgbuild elects to download them ahead of time so their checksums can be validated.
 # See:
-# https://github.com/NVIDIA/libnvidia-container/blob/56704b8dd297bf4daf82a2da4b270dc7f14e0008/mk/libtirpc.mk
 # https://github.com/NVIDIA/libnvidia-container/blob/e3a2035da5a44b8a83d9568b91a8a0b542ee15d5/mk/elftoolchain.mk
 # https://github.com/NVIDIA/libnvidia-container/blob/56704b8dd297bf4daf82a2da4b270dc7f14e0008/mk/nvidia-modprobe.mk
 source=("https://github.com/NVIDIA/${pkgname}/archive/v${pkgver}.tar.gz"
-        "https://downloads.sourceforge.net/project/libtirpc/libtirpc/${_rpcver}/libtirpc-${_rpcver}.tar.bz2"
         "https://sourceforge.net/projects/elftoolchain/files/Sources/elftoolchain-${_elfver}/elftoolchain-${_elfver}.tar.bz2"
         "https://github.com/NVIDIA/nvidia-modprobe/archive/396.51.tar.gz")
 sha256sums=('5c8ca77e490fd9a0a47020fa0d6d9842af4951bfcb12d189db37ad5524b67f27'
-            '2ca529f02292e10c158562295a1ffd95d2ce8af97820e3534fe1b0e3aec7561d'
             '44f14591fcf21294387215dd7562f3fb4bec2f42f476cf32420a6bbabb2bd2b5'
             '25bc6437a384be670e9fd76ac2e5b9753517e23eb16e7fa891b18537b70c4b20')
 
@@ -43,7 +39,7 @@ prepare(){
   deps_dir="${srcdir}/${pkgname}-${pkgver}/deps/src/"
   # mimic behavior from:
   # https://github.com/NVIDIA/libnvidia-container/blob/56704b8dd297bf4daf82a2da4b270dc7f14e0008/mk/libtirpc.mk
-  for dep in "libtirpc-${_rpcver}.tar.bz2" "elftoolchain-${_elfver}.tar.bz2" "${_nvmpver}.tar.gz"; do
+  for dep in "elftoolchain-${_elfver}.tar.bz2" "${_nvmpver}.tar.gz"; do
     dep_dir="${deps_dir}/${dep%.tar*}"
     mkdir -p ${dep_dir}
     # untar the download into the deps dir


### PR DESCRIPTION
`libtirpc` is not needed as source since added as dependency in d056cd0beecf300242c8a2217939d65d11795157